### PR TITLE
Web: project overview tags

### DIFF
--- a/web/src/pages/projects/ProjectCard.js
+++ b/web/src/pages/projects/ProjectCard.js
@@ -2,11 +2,13 @@ import React, { useEffect, useState } from "react";
 import { Box, Button, Card, CardActionArea, CardActions, CardContent, CardMedia, Chip, Divider, Typography } from '@mui/material'
 import { getNameByProjectUrl, getProjectMetaData, getThumbnailUrl } from "../../scripts/ProjectFetcher";
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
-import { useHistory, useNavigate } from 'react-router-dom';
+import { useHistory, useNavigate, useSearchParams } from 'react-router-dom';
+import TagBtn from './TagBtn'
 
 function ProjectCard({projectUrl}){
     const [projectMeta, setProjectMeta] = useState({"tags": []});
     const [projectThumbnailUrl, setProjectThumbnailUrl] = useState("");
+    const [searchparams, setSearchParams] = useSearchParams();
 
     useEffect(() => {
         async function fetchMetaData(){
@@ -53,20 +55,11 @@ function ProjectCard({projectUrl}){
                 
             </CardActionArea>
             <CardActions sx={{ display:'flex', flexWrap:'wrap', alignContent: 'flex-start'}}>
-                {projectMeta.tags.map((tag) =>
-                    <Button
-                        key={tag} 
-                        color="secondary"
-                        size="small"
-                        variant="outlined"
-                        sx={{
-                            textTransform: 'capitalize'
-                        }}
-                    >
-                            {tag}
-                    </Button>
-                )
-                }
+                {projectMeta.tags.map((tag) => <TagBtn 
+                                                    key={tag}
+                                                    tag={tag} 
+                                                    onClick={() => setSearchParams({'tag':tag})}
+                                                /> )}
             </CardActions> 
         </Card>
     );

--- a/web/src/pages/projects/ProjectCard.js
+++ b/web/src/pages/projects/ProjectCard.js
@@ -45,6 +45,7 @@ function ProjectCard({projectUrl, projectMeta, projectThumbnailUrl}){
                                                     key={tag}
                                                     tag={tag} 
                                                     onClick={() => setSearchParams({'tag':tag})}
+                                                    variant='outlined'
                                                 /> )}
             </CardActions> 
         </Card>

--- a/web/src/pages/projects/ProjectCard.js
+++ b/web/src/pages/projects/ProjectCard.js
@@ -5,31 +5,17 @@ import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import { useHistory, useNavigate, useSearchParams } from 'react-router-dom';
 import TagBtn from './TagBtn'
 
-function ProjectCard({projectUrl}){
-    const [projectMeta, setProjectMeta] = useState({"tags": []});
-    const [projectThumbnailUrl, setProjectThumbnailUrl] = useState("");
+function ProjectCard({projectUrl, projectMeta, projectThumbnailUrl}){
     const [searchparams, setSearchParams] = useSearchParams();
 
-    useEffect(() => {
-        async function fetchMetaData(){
-            setProjectMeta(await getProjectMetaData(projectUrl));
-        }
-        fetchMetaData();
-    }, [])
-
-    useEffect(() => {
-        async function fetchThumbnailUrl(){
-            setProjectThumbnailUrl(await getThumbnailUrl(projectUrl));
-        }
-        fetchThumbnailUrl();
-    }, [])
     const navigate = useNavigate();
     function handleRoute(){
         navigate(`${projectUrl.split('/').pop()}`);
 
     }   
     
-    return(
+    return (
+
         <Card sx= {{ maxWidth:400, m:1, display: 'flex', flexDirection: 'column'}}>
             <CardActionArea onClick={handleRoute} sx= {{  display: 'flex', flexDirection: 'column', flexGrow:1 }}>
                 <CardMedia

--- a/web/src/pages/projects/Projects.js
+++ b/web/src/pages/projects/Projects.js
@@ -1,11 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import ProjectCard from './ProjectCard';
 import { getAllProjectUrls, getAllTags } from '../../scripts/ProjectFetcher';
-import { Card, Grid } from '@mui/material';
+import { Card, Grid, Box } from '@mui/material';
+import { useSearchParams } from 'react-router-dom';
+import TagBtn from './TagBtn';
 
 
 function Projects(){
     const [projectUrls, setProjectUrls] = useState([]);
+    const [tags, setTags] = useState([]);
+    const [searchparams, setSearchParams] = useSearchParams();
+    const [selectedTag, setSelectedTag] = useState("");
 
     useEffect(() => {
         async function fetchProjectUrls(){
@@ -14,16 +19,38 @@ function Projects(){
         fetchProjectUrls();
     }, []);
 
+    useEffect(() => {
+        async function fetchTags(){
+            setTags(await getAllTags());
+        }
+        fetchTags();
+    }, []);
+
+    
     
     return (
-        <Grid container my={1} >
-            {projectUrls.map((projectUrl) => 
-                <Grid item key={projectUrl} xs={12} sm={6} md={4} display='flex' justifyContent='center'>
-                    <ProjectCard key={projectUrl} projectUrl={projectUrl} />
-                </Grid>
-                )
-            }
-        </Grid>
+        <div>
+            <Box sx={{display:'flex'}}>
+                <TagBtn tag='all' onClick={() => {
+                    const params = searchparams;
+                    params.delete('tag');
+                    setSearchParams(params);
+                }} />
+                {tags.map((tag) => <TagBtn 
+                                        key={tag} 
+                                        tag={tag}
+                                        onClick={() => setSearchParams({'tag':tag})}
+                                    />)}
+            </Box>
+            <Grid container my={1} >
+                {projectUrls.map((projectUrl) => 
+                    <Grid item key={projectUrl} xs={12} sm={6} md={4} display='flex' justifyContent='center'>
+                        <ProjectCard key={projectUrl} projectUrl={projectUrl} />
+                    </Grid>
+                    )
+                }
+            </Grid>
+        </div>
     );
 }
 export default Projects;

--- a/web/src/pages/projects/Projects.js
+++ b/web/src/pages/projects/Projects.js
@@ -52,16 +52,18 @@ function Projects(){
     
     return (
         <div>
-            <Box sx={{display:'flex'}}>
+            <Box sx={{display:'flex', justifyContent:'center', mt:2}}>
                 <TagBtn tag='all' onClick={() => {
                     const params = searchparams;
                     params.delete('tag');
                     setSearchParams(params);
-                }} />
+                }} mx={0.5} variant={selectedTag == null ? 'contained' : 'outlined'} />
                 {tags.map((tag) => <TagBtn 
                                         key={tag} 
                                         tag={tag}
                                         onClick={() => setSearchParams({'tag':tag})}
+                                        mx={0.5}
+                                        variant={selectedTag === tag ? 'contained' : 'outlined'}
                                     />)}
             </Box>
             <Grid container my={1} >

--- a/web/src/pages/projects/TagBtn.js
+++ b/web/src/pages/projects/TagBtn.js
@@ -1,0 +1,20 @@
+import { Button } from "@mui/material";
+import React from "react";
+
+function TagBtn({tag, onClick}){
+    return(
+        <Button
+            onClick={() => onClick()}
+            color="secondary"
+            size="small"
+            variant="outlined"
+            sx={{
+                textTransform: 'capitalize'
+            }}
+        >
+            {tag}
+        </Button>
+    );
+}
+
+export default TagBtn;

--- a/web/src/pages/projects/TagBtn.js
+++ b/web/src/pages/projects/TagBtn.js
@@ -1,15 +1,16 @@
 import { Button } from "@mui/material";
 import React from "react";
 
-function TagBtn({tag, onClick}){
+function TagBtn({tag, onClick, variant, ...props}){
     return(
         <Button
             onClick={() => onClick()}
             color="secondary"
             size="small"
-            variant="outlined"
+            variant={variant}
             sx={{
-                textTransform: 'capitalize'
+                textTransform: 'capitalize',
+                ...props
             }}
         >
             {tag}

--- a/web/src/scripts/ProjectFetcher.js
+++ b/web/src/scripts/ProjectFetcher.js
@@ -67,5 +67,21 @@ export async function getAllTags(){
         }
         projectMetaData.tags.forEach( (tag) => {tags.add(tag)} );
     }
-    return tags;
+    return Array.from(tags);
+}
+
+export async function getProjectUrlsWithTag(tag){
+    const urls = await getAllProjectUrls();
+    const projectUrls = []
+    for(const projectUrl of urls){
+        const projectMetaData = await getProjectMetaData(projectUrl);
+        if(projectMetaData == null){
+            continue;
+        }
+        // check if contains a valid tag
+        if(projectMetaData.tags.includes(tag)){
+            projectUrls.add(projectUrl);
+        }
+    }
+    return projectUrls;
 }


### PR DESCRIPTION
# Project overview tags
The projects contain tags. In the project overview page it is now possible to filter the projects by tag.
This is also added to the query parameter in the url. The fileter is not lost when returning to the overview page from a detail page. One can either click on the filter buttons on the top, or on the tag buttons in the cards.

## Screenshots
![image](https://github.com/brmatthy/blog/assets/109791839/0e401b0b-64d8-4133-8b29-bf5e62ba753c)
![image](https://github.com/brmatthy/blog/assets/109791839/da6a69fd-b43f-42bb-8a8d-c3a49a294b84)
